### PR TITLE
[Error Fix] Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null.

### DIFF
--- a/lib/src/flutter_radar_map.dart
+++ b/lib/src/flutter_radar_map.dart
@@ -505,7 +505,7 @@ class RadarMapPainter extends CustomPainter {
     //   print("${element.left} . ${element.top} 11");
     // });
 
-    WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
+    WidgetsBinding.instance.addPostFrameCallback((timeStamp) {
       _widthHeight.call(top,bottom);
     });
 

--- a/lib/src/radar_map_model.dart
+++ b/lib/src/radar_map_model.dart
@@ -1,3 +1,5 @@
+// Modeified by SehunKIM 2023.02.07
+
 import 'package:flutter/material.dart';
 // 圆形雷达图和方形雷达图
 enum Shape { circle, square }


### PR DESCRIPTION
When I use this package error of under line occurred.
"Operand of null-aware operation '!' has type 'WidgetsBinding' which excludes null."

So I update and fix this line "kg_charts-0.0.5/lib/src/flutter_radar_map.dart:508:20" from WidgetsBinding.instance!.addPostFrameCallback((timeStamp) to WidgetsBinding.instance.addPostFrameCallback((timeStamp).