### PR TITLE
using LayoutBuilder's constraints but not screen size to draw canvas

### DIFF
--- a/test/kg_charts_test.dart
+++ b/test/kg_charts_test.dart
@@ -34,7 +34,7 @@ void main() {
       textStyle: const TextStyle(color: Colors.black, fontSize: 14),
       isNeedDrawLegend: true,
       lineText: (p, length) => "${(p * 100 ~/ length)}%",
-      dilogText: (IndicatorModel indicatorModel, List<LegendModel> legendModels,
+      dialogText: (IndicatorModel indicatorModel, List<LegendModel> legendModels,
           List<double> mapDataModels) {
         StringBuffer text = StringBuffer("");
         for (int i = 0; i < mapDataModels.length; i++) {


### PR DESCRIPTION
On large screen devices, drawing the Canvas using its full width may result in layout errors, and using constraints from a LayoutBuilder may be a better idea.

![图片](https://github.com/smartbackme/kg_charts/assets/24912203/1d30d95d-7fbb-443c-89ac-b664dda36351)

```dart
return Scaffold(
      body: Row(
        mainAxisAlignment: MainAxisAlignment.start,
        crossAxisAlignment: CrossAxisAlignment.start,
        children: [
          Container(
            color: Colors.grey,
            width: 400,
            height: 400,
            child: RadarWidget(
```